### PR TITLE
Clamp Monster Run

### DIFF
--- a/Source/ACE.Server/Physics/Animation/MovementSystem.cs
+++ b/Source/ACE.Server/Physics/Animation/MovementSystem.cs
@@ -22,7 +22,7 @@ namespace ACE.Server.Physics.Animation
             var loadMod = EncumbranceSystem.GetBurdenMod(burden);
 
             if (runSkill >= 800.0f)     // max run speed?
-                return 18.0f / 4.0f;
+                return (18.0f / 4.0f) / scaling;
             else
                 return ((loadMod * ((float)runSkill / (runSkill + 200) * 11) + 4) / scaling) / 4.0f;
         }

--- a/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Navigation.cs
@@ -296,9 +296,13 @@ namespace ACE.Server.WorldObjects
 
             RunRate = GetRunRate();
 
-            MoveSpeed = moveSpeed * RunRate * scale;
+            // Calculate raw speed (with scale logic)
+            MoveSpeed = moveSpeed * RunRate;
 
-            //Console.WriteLine(Name + " - Run: " + runSkill + " - RunRate: " + RunRate + " - Move: " + MoveSpeed + " - Scale: " + scale);
+            // Cap: never faster than 800 run at 1.0 scale
+            var maxMoveSpeed = moveSpeed * (18.0f / 4.0f); // 4.5 is the capped RunRate
+            if (MoveSpeed > maxMoveSpeed)
+                MoveSpeed = maxMoveSpeed;
         }
 
         /// <summary>


### PR DESCRIPTION
Clamp monster run rate / scale

The cap is enforced regardless of run skill or scale, preventing small or high-run-skill creatures from exceeding the intended maximum speed.
- For run skill below 800, movement speed is calculated using the standard formula and is not capped.
- For scale > 1.0 (giant models), movement speed is further reduced, causing large creatures to move slower (“lumber”).
- For scale < 1.0 (small models), movement speed is capped at the player maximum, so small creatures cannot move faster than a capped player.
- The cap is based on the motion table’s base run speed and a run rate of 4.5 (the value for 800 run skill).

Note: Some motion tables still go insane with this, but this is still an improvement to the overall system.

Tested with Boots and Dargoth Hera against custom Tremendous Monouga (VoD) and Olthoi Sentinel (VoD)